### PR TITLE
Remove NEWLINE from the beginning of the string

### DIFF
--- a/discord_markdown/parser.py
+++ b/discord_markdown/parser.py
@@ -41,10 +41,11 @@ class Parser:
             if current_token.type not in NONFORMAT_TOKEN_TYPES:
                 self._stack.append(current_token)
             else:
-                node = AST_BY_TOKEN_TYPE[TokenSpecification.TEXT.name](
-                    current_token.value
-                )
-                elems.append(node)
+                if current_token.type != TokenSpecification.NEWLINE.name:
+                    node = AST_BY_TOKEN_TYPE[TokenSpecification.TEXT.name](
+                        current_token.value
+                    )
+                    elems.append(node)
 
             current_token = next(self.token_iter)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -14,7 +14,7 @@ def test_compile_formatted():
     compiler = Compiler(text)
     assert (
         compiler.compile()
-        == "<p>Here I <i>am</i> in the <b>light</b> of <b><i>day</i></b></p><p>\nLet the storm rage on</p>"
+        == "<p>Here I <i>am</i> in the <b>light</b> of <b><i>day</i></b></p><p>Let the storm rage on</p>"
     )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,8 +30,8 @@ def test_paragraph_text():
         parser.tree,
         [
             ast.Paragraph([ast.Text("This is the first paragraph.")]),
-            ast.Paragraph([ast.Text("\n"), ast.Text("This is the second one.")]),
-            ast.Paragraph([ast.Text("\n"), ast.Text("This is the third one.")]),
+            ast.Paragraph([ast.Text("This is the second one.")]),
+            ast.Paragraph([ast.Text("This is the third one.")]),
         ],
     )
 
@@ -73,7 +73,7 @@ def test_bold_italics_text():
                     ast.BoldText(ast.ItalicText(ast.Text("day"))),
                 ]
             ),
-            ast.Paragraph([ast.Text("\nLet the storm rage on")]),
+            ast.Paragraph([ast.Text("Let the storm rage on")]),
         ],
     )
 
@@ -162,12 +162,7 @@ def test_multiple_formatted_text():
                 ]
             ),
             ast.Paragraph(
-                [
-                    ast.Text("\n"),
-                    ast.Text("I "),
-                    ast.BoldText(ast.Text("am")),
-                    ast.Text(" depressed."),
-                ]
+                [ast.Text("I "), ast.BoldText(ast.Text("am")), ast.Text(" depressed."),]
             ),
         ],
     )


### PR DESCRIPTION
Newlines were being included in the parsed node values instead of being omitted (if at the beginning).