### PR TITLE
Add import statement to __init__.py

### DIFF
--- a/discord_markdown/__init__.py
+++ b/discord_markdown/__init__.py
@@ -1,1 +1,2 @@
+from .discord_markdown import *
 __version__ = "0.1.0"


### PR DESCRIPTION
Allows use of "import discord_markdown" instead of "from discord_markdown import discord_markdown".